### PR TITLE
Implement CollectorRegistry for shared collectors

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -12,6 +12,7 @@ use LaminasMicroscope\DebugBar\Collectors\LaminasConfigCollector;
 use LaminasMicroscope\DebugBar\Collectors\LaminasRequestCollector;
 use LaminasMicroscope\DebugBar\EventListener\QueryLogger;
 use LaminasMicroscope\Microscope\MicroscopeHandler;
+use LaminasMicroscope\Collector\CollectorRegistry;
 use LaminasMicroscope\Controller\MicroscopeController;
 use LaminasMicroscope\Controller\DashboardController;
 use LaminasMicroscope\Controller\ConfigurationController;
@@ -167,6 +168,9 @@ return [
                  // Instantiate AnalysisService with ConfigurationService and MicroscopeHandler
                  return new AnalysisService($config, $microscopeHandler); // Pass all dependencies
             },
+            CollectorRegistry::class => function () {
+                return new \LaminasMicroscope\Collector\CollectorRegistry();
+            },
             // Factory for WhoopsHandler
             // Changed type hint from ContainerInterface to ServiceManager
             WhoopsHandler::class => function (Laminas\ServiceManager\ServiceManager $container) {
@@ -178,16 +182,16 @@ return [
             // Changed type hint from ContainerInterface to ServiceManager
             DebugBarHandler::class => function (Laminas\ServiceManager\ServiceManager $container) {
                 $config = $container->get(ConfigurationService::class);
-                // DebugBarHandler constructor now takes ConfigurationService and Container
-                return new DebugBarHandler($config, $container); // Pass the container
+                $registry = $container->get(CollectorRegistry::class);
+                return new DebugBarHandler($config, $container, $registry);
             },
             // Factory for MicroscopeHandler
             // Changed type hint from ContainerInterface to ServiceManager
             MicroscopeHandler::class => function (Laminas\ServiceManager\ServiceManager $container) {
-                // MicroscopeHandler constructor takes ComponentManager, ConfigurationService, and ContainerInterface
                 $componentManager = $container->get(ComponentManager::class);
                 $config = $container->get(ConfigurationService::class);
-                return new MicroscopeHandler($componentManager, $config, $container);
+                $registry = $container->get(CollectorRegistry::class);
+                return new MicroscopeHandler($componentManager, $config, $container, $registry);
             },
             // Debug Bar Collectors
             PDOCollector::class => function (Laminas\ServiceManager\ServiceManager $container) {

--- a/src/Collector/CollectorInterface.php
+++ b/src/Collector/CollectorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasMicroscope\Collector;
+
+interface CollectorInterface
+{
+    public function getName(): string;
+}

--- a/src/Collector/CollectorRegistry.php
+++ b/src/Collector/CollectorRegistry.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasMicroscope\Collector;
+
+class CollectorRegistry
+{
+    /** @var array<string, object> */
+    private array $collectors = [];
+
+    public function register(object $collector): void
+    {
+        if (method_exists($collector, 'getName')) {
+            $name = $collector->getName();
+            $this->collectors[$name] = $collector;
+        }
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->collectors[$name]);
+    }
+
+    public function get(string $name): object|null
+    {
+        return $this->collectors[$name] ?? null;
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    public function all(): array
+    {
+        return $this->collectors;
+    }
+}

--- a/src/DebugBar/Collectors/LaminasConfigCollector.php
+++ b/src/DebugBar/Collectors/LaminasConfigCollector.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace LaminasMicroscope\DebugBar\Collectors;
 
+use LaminasMicroscope\Collector\CollectorInterface;
+
 use DebugBar\DataCollector\DataCollector; // Corrected namespace
 use DebugBar\DataCollector\Renderable; // Corrected namespace
 use Laminas\ServiceManager\ServiceManager; // Corrected namespace
 use Exception; // Corrected namespace
 use ReflectionClass; // Corrected namespace
 
-class LaminasConfigCollector extends DataCollector implements Renderable
+class LaminasConfigCollector extends DataCollector implements Renderable, CollectorInterface
 {
     private ServiceManager $serviceManager;
 

--- a/src/DebugBar/Collectors/LaminasRequestCollector.php
+++ b/src/DebugBar/Collectors/LaminasRequestCollector.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace LaminasMicroscope\DebugBar\Collectors;
 
+use LaminasMicroscope\Collector\CollectorInterface;
+
 use DebugBar\DataCollector\DataCollector; // Corrected namespace
 use DebugBar\DataCollector\Renderable; // Corrected namespace
 use Laminas\ServiceManager\ServiceManager; // Corrected namespace
 use Exception; // Corrected namespace
 
-class LaminasRequestCollector extends DataCollector implements Renderable
+class LaminasRequestCollector extends DataCollector implements Renderable, CollectorInterface
 {
     private ServiceManager $serviceManager;
 

--- a/src/DebugBar/Collectors/PDOCollector.php
+++ b/src/DebugBar/Collectors/PDOCollector.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace LaminasMicroscope\DebugBar\Collectors;
 
+use LaminasMicroscope\Collector\CollectorInterface;
+
 use DebugBar\DataCollector\DataCollector; // Corrected namespace
 use DebugBar\DataCollector\Renderable; // Corrected namespace
 use Laminas\ServiceManager\ServiceManager; // Corrected namespace
 use Exception; // Corrected namespace
 use Laminas\Db\Adapter\Adapter; // Added use statement
 
-class PDOCollector extends DataCollector implements Renderable
+class PDOCollector extends DataCollector implements Renderable, CollectorInterface
 {
     private ServiceManager $serviceManager;
     private array $queries = [];

--- a/src/DebugBar/DebugBarHandler.php
+++ b/src/DebugBar/DebugBarHandler.php
@@ -23,6 +23,7 @@ use Laminas\ServiceManager\ServiceManager;
 use Psr\Container\ContainerInterface;
 use Laminas\View\Renderer\RendererInterface;
 use DebugBar\JavascriptRenderer;
+use LaminasMicroscope\Collector\CollectorRegistry;
 
 /**
  * Handler for DebugBar integration
@@ -32,13 +33,16 @@ class DebugBarHandler
     private ?StandardDebugBar $debugBar = null;
     private bool $initialized = false;
     private ContainerInterface $container;
+    private CollectorRegistry $collectorRegistry;
     private ?JavascriptRenderer $renderer = null;
 
     public function __construct(
         private ConfigurationService $configService,
-        ContainerInterface $container
+        ContainerInterface $container,
+        CollectorRegistry $collectorRegistry
     ) {
         $this->container = $container;
+        $this->collectorRegistry = $collectorRegistry;
         // --- NEW DEBUG LOGGING ---
         error_log("LaminasMicroscope: DEBUG: DebugBarHandler::__construct() called. Instance hash: " . spl_object_hash($this) . ".\n");
         // --- END NEW DEBUG LOGGING ---
@@ -449,12 +453,19 @@ class DebugBarHandler
             // --- END DEBUG LOGGING ---
             return;
         }
+        $existing = $this->collectorRegistry->get($name);
+        if ($existing && !$this->debugBar->hasCollector($existing->getName())) {
+            $this->debugBar->addCollector($existing);
+            return;
+        }
 
         switch ($name) {
             case 'time':
                 if (!$this->debugBar->hasCollector('time')) {
                     try {
-                        $this->debugBar->addCollector(new TimeDataCollector());
+                        $collector = new TimeDataCollector();
+                        $this->debugBar->addCollector($collector);
+                        $this->collectorRegistry->register($collector);
                          // --- DEBUG LOGGING ---
                         error_log("LaminasMicroscope: DEBUG: TimeDataCollector added.\n");
                         // --- END DEBUG LOGGING ---
@@ -474,7 +485,9 @@ class DebugBarHandler
             case 'memory':
                 if (!$this->debugBar->hasCollector('memory')) {
                     try {
-                        $this->debugBar->addCollector(new MemoryCollector());
+                        $collector = new MemoryCollector();
+                        $this->debugBar->addCollector($collector);
+                        $this->collectorRegistry->register($collector);
                          // --- DEBUG LOGGING ---
                         error_log("LaminasMicroscope: DEBUG: MemoryCollector added.\n");
                         // --- END DEBUG LOGGING ---
@@ -494,7 +507,9 @@ class DebugBarHandler
             case 'messages':
                 if (!$this->debugBar->hasCollector('messages')) {
                     try {
-                        $this->debugBar->addCollector(new MessagesCollector());
+                        $collector = new MessagesCollector();
+                        $this->debugBar->addCollector($collector);
+                        $this->collectorRegistry->register($collector);
                          // --- DEBUG LOGGING ---
                         error_log("LaminasMicroscope: DEBUG: MessagesCollector added.\n");
                         // --- END DEBUG LOGGING ---
@@ -516,7 +531,9 @@ class DebugBarHandler
                 $customKey = 'microscope_php';
                 if (!$this->debugBar->hasCollector($customKey)) {
                     try {
-                        $this->debugBar->addCollector(new PhpInfoCollector(), $customKey);
+                        $collector = new PhpInfoCollector();
+                        $this->debugBar->addCollector($collector, $customKey);
+                        $this->collectorRegistry->register($collector);
                          // --- DEBUG LOGGING ---
                         error_log("LaminasMicroscope: DEBUG: PhpInfoCollector added with key \"{$customKey}\".\n");
                         // --- END DEBUG LOGGING ---

--- a/src/Microscope/MicroscopeHandler.php
+++ b/src/Microscope/MicroscopeHandler.php
@@ -8,6 +8,7 @@ use LaminasMicroscope\Manager\ComponentManager;
 use LaminasMicroscope\Config\ConfigurationService;
 use LaminasMicroscope\Microscope\Storage\ReportStorage;
 use Laminas\Mvc\MvcEvent;
+use LaminasMicroscope\Collector\CollectorRegistry;
 use Psr\Container\ContainerInterface;
 use Exception;
 use RuntimeException;
@@ -21,6 +22,7 @@ class MicroscopeHandler
     private ComponentManager $componentManager;
     private ConfigurationService $configService;
     private ContainerInterface $container;
+    private CollectorRegistry $collectorRegistry;
     private ReportStorage $storage;
     private array $profileData = [];
     private float $requestStartTime; // Overall request start time
@@ -30,11 +32,13 @@ class MicroscopeHandler
     public function __construct(
         ComponentManager $componentManager,
         ConfigurationService $configService,
-        ContainerInterface $container
+        ContainerInterface $container,
+        CollectorRegistry $collectorRegistry
     ) {
         $this->componentManager = $componentManager;
         $this->configService = $configService;
         $this->container = $container;
+        $this->collectorRegistry = $collectorRegistry;
     }
 
     /**
@@ -200,6 +204,19 @@ class MicroscopeHandler
     }
 
     /**
+     * Retrieve query log from shared collectors
+     */
+    private function getQueries(): array
+    {
+        $pdo = $this->collectorRegistry->get('pdo');
+        if ($pdo && method_exists($pdo, 'collect')) {
+            $data = $pdo->collect();
+            return $data['statements'] ?? [];
+        }
+        return $this->profileData['queries'] ?? [];
+    }
+
+    /**
      * Run comprehensive analysis
      */
     public function runAnalysis(): array
@@ -217,7 +234,7 @@ class MicroscopeHandler
         $analysis = [
             'id' => uniqid('analysis_', true),
             'created_at' => date('Y-m-d H:i:s'),
-            'queries' => $this->profileData['queries'] ?? [],
+            'queries' => $this->getQueries(),
             'performance' => $this->profileData['performance'] ?? [],
             'issues' => [],
             'performance_score' => 100,
@@ -279,9 +296,14 @@ class MicroscopeHandler
             return;
         }
 
-        $this->profileData['queries'][] = array_merge($queryData, [
-            'timestamp' => microtime(true),
-        ]);
+        $queryData['timestamp'] = microtime(true);
+        $pdo = $this->collectorRegistry->get('pdo');
+        if ($pdo && method_exists($pdo, 'addQuery')) {
+            $pdo->addQuery($queryData);
+            return;
+        }
+
+        $this->profileData['queries'][] = $queryData;
     }
 
     /**
@@ -321,7 +343,7 @@ class MicroscopeHandler
      */
     private function findDuplicateQueries(): array
     {
-        $queries = $this->profileData['queries'] ?? [];
+        $queries = $this->getQueries();
         $queryMap = [];
         $duplicates = [];
 
@@ -357,7 +379,7 @@ class MicroscopeHandler
      */
     private function findSlowQueries(): array
     {
-        $queries = $this->profileData['queries'] ?? [];
+        $queries = $this->getQueries();
         $slowQueries = [];
         $threshold = $this->configService->get('laminas_microscope.components.microscope.thresholds.query_time', 100);
 

--- a/tests/Functional/DebugBarIntegrationTest.php
+++ b/tests/Functional/DebugBarIntegrationTest.php
@@ -12,6 +12,8 @@ class DebugBarIntegrationTest extends TestCase
 {
     private DebugBarHandler $debugBar;
     private ConfigurationService $configService;
+    private object $container;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
 
     protected function setUp(): void
     {
@@ -30,7 +32,9 @@ class DebugBarIntegrationTest extends TestCase
         ]);
         
         $this->configService = new ConfigurationService($config);
-        $this->debugBar = new DebugBarHandler($this->configService);
+        $this->container = \TestHelper::createMockServiceManager();
+        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+        $this->debugBar = new DebugBarHandler($this->configService, $this->container, $this->registry);
     }
 
     protected function tearDown(): void
@@ -164,7 +168,7 @@ class DebugBarIntegrationTest extends TestCase
         ]);
         
         $disabledConfigService = new ConfigurationService($disabledConfig);
-        $disabledDebugBar = new DebugBarHandler($disabledConfigService);
+        $disabledDebugBar = new DebugBarHandler($disabledConfigService, $this->container, $this->registry);
         
         $this->assertFalse($disabledDebugBar->isEnabled());
         
@@ -268,7 +272,7 @@ class DebugBarIntegrationTest extends TestCase
         ]);
         
         $prodConfigService = new ConfigurationService($prodConfig);
-        $prodDebugBar = new DebugBarHandler($prodConfigService);
+        $prodDebugBar = new DebugBarHandler($prodConfigService, $this->container, $this->registry);
         
         $this->assertFalse($prodDebugBar->shouldDisplay());
         
@@ -287,7 +291,7 @@ class DebugBarIntegrationTest extends TestCase
         ]);
         
         $prodEnabledConfigService = new ConfigurationService($prodEnabledConfig);
-        $prodEnabledDebugBar = new DebugBarHandler($prodEnabledConfigService);
+        $prodEnabledDebugBar = new DebugBarHandler($prodEnabledConfigService, $this->container, $this->registry);
         
         $this->assertTrue($prodEnabledDebugBar->shouldDisplay());
     }
@@ -340,7 +344,7 @@ class DebugBarIntegrationTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $debugBar = new DebugBarHandler($configService);
+        $debugBar = new DebugBarHandler($configService, $this->container, $this->registry);
         
         if (!$debugBar->isEnabled()) {
             $this->markTestSkipped('Debug bar is not enabled');
@@ -393,7 +397,7 @@ class DebugBarIntegrationTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $debugBar = new DebugBarHandler($configService);
+        $debugBar = new DebugBarHandler($configService, $this->container, $this->registry);
         
         if (!$debugBar->isEnabled()) {
             $this->markTestSkipped('Debug bar is not enabled');

--- a/tests/Functional/MicroscopeAnalysisTest.php
+++ b/tests/Functional/MicroscopeAnalysisTest.php
@@ -60,12 +60,14 @@ class MicroscopeAnalysisTest extends TestCase
         $this->configService = new ConfigurationService($config);
         $this->componentManager = new ComponentManager($this->configService);
         $this->container = $this->createMock(ContainerInterface::class);
+        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
         
         // Create MicroscopeHandler with correct constructor signature
         $this->microscope = new MicroscopeHandler(
             $this->componentManager,
             $this->configService,
-            $this->container
+            $this->container,
+            $this->registry
         );
         
         $this->tempDir = \TestHelper::createTempDir();

--- a/tests/Unit/DebugBar/DebugBarHandlerTest.php
+++ b/tests/Unit/DebugBar/DebugBarHandlerTest.php
@@ -12,6 +12,8 @@ class DebugBarHandlerTest extends TestCase
 {
     private DebugBarHandler $handler;
     private ConfigurationService $configService;
+    private object $container;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
 
     protected function setUp(): void
     {
@@ -29,7 +31,9 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $this->configService = new ConfigurationService($config);
-        $this->handler = new DebugBarHandler($this->configService);
+        $this->container = \TestHelper::createMockServiceManager();
+        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+        $this->handler = new DebugBarHandler($this->configService, $this->container, $this->registry);
     }
 
     public function testIsEnabledReturnsTrueWhenDebugBarEnabled(): void
@@ -51,7 +55,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $this->assertFalse($handler->isEnabled());
     }
@@ -70,7 +74,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $this->assertFalse($handler->isEnabled());
     }
@@ -97,7 +101,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $handler->initialize();
         
@@ -127,7 +131,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $this->assertNull($handler->getRenderer());
     }
@@ -200,7 +204,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $html = $handler->renderHtml();
         $this->assertEquals('', $html);
@@ -220,7 +224,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $assets = $handler->getAssets();
         $this->assertEquals(['css' => [], 'js' => []], $assets);
@@ -241,7 +245,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $this->assertTrue($handler->shouldDisplay());
     }
@@ -262,7 +266,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $this->assertFalse($handler->shouldDisplay());
     }
@@ -283,7 +287,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $this->assertTrue($handler->shouldDisplay());
     }
@@ -591,7 +595,7 @@ class DebugBarHandlerTest extends TestCase
             ]);
             
             $configService = new ConfigurationService($config);
-            $handler = new DebugBarHandler($configService);
+            $handler = new DebugBarHandler($configService, $this->container, $this->registry);
             
             $handler->initialize();
             $collectors = $handler->getCollectors();
@@ -642,7 +646,7 @@ class DebugBarHandlerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $handler = new DebugBarHandler($configService);
+        $handler = new DebugBarHandler($configService, $this->container, $this->registry);
         
         $collectors = $handler->getCollectors();
         $this->assertIsArray($collectors);

--- a/tests/Unit/Microscope/MicroscopeHandlerTest.php
+++ b/tests/Unit/Microscope/MicroscopeHandlerTest.php
@@ -19,6 +19,7 @@ class MicroscopeHandlerTest extends TestCase
     private ComponentManager $componentManager;
     private ConfigurationService $configService;
     private ContainerInterface $container;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
 
     protected function setUp(): void
     {
@@ -26,12 +27,14 @@ class MicroscopeHandlerTest extends TestCase
         $this->componentManager = $this->createMock(ComponentManager::class);
         $this->configService = $this->createMock(ConfigurationService::class);
         $this->container = $this->createMock(ContainerInterface::class);
+        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
         
         // Create the real handler with mocked dependencies
         $this->handler = new MicroscopeHandler(
             $this->componentManager,
             $this->configService,
-            $this->container
+            $this->container,
+            $this->registry
         );
     }
 


### PR DESCRIPTION
## Summary
- add `CollectorRegistry` with simple register/get methods
- implement registry usage in `DebugBarHandler`
- share PDO queries with `MicroscopeHandler`
- wire CollectorRegistry into service configuration
- update tests for new constructor signatures

## Testing
- `composer install` *(fails: missing PHP extensions)*
- `vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684349d0ec348331bfbd4aa09935d567