### PR TITLE
Inject CollectorRegistry into component manager

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -148,9 +148,9 @@ return [
             // Changed type hint from ContainerInterface to ServiceManager
             ComponentManager::class => function (Laminas\ServiceManager\ServiceManager $container) {
                 $config = $container->get(ConfigurationService::class);
-                // Pass the container to ComponentManager if its constructor requires it
-                // Based on ComponentManager.php, it takes ConfigurationService and optional ContainerInterface
-                return new ComponentManager($config, $container);
+                $registry = $container->get(CollectorRegistry::class);
+                // Pass the container and collector registry to ComponentManager
+                return new ComponentManager($config, $container, $registry);
             },
             // Factory for ConfigurationManager
             // Changed type hint from ContainerInterface to ServiceManager

--- a/src/Manager/ComponentManager.php
+++ b/src/Manager/ComponentManager.php
@@ -9,8 +9,9 @@ use LaminasMicroscope\DebugBar\DebugBarHandler;
 use LaminasMicroscope\Whoops\WhoopsHandler;
 use LaminasMicroscope\Service\AnalysisService;
 use Psr\Container\ContainerInterface;
-use LaminasMicroscope\Container\MockContainer; 
+use LaminasMicroscope\Container\MockContainer;
 use LaminasMicroscope\Microscope\MicroscopeHandler; // Added use statement
+use LaminasMicroscope\Collector\CollectorRegistry;
 use Exception; // Added use statement
 
 /**
@@ -20,11 +21,14 @@ class ComponentManager
 {
     private array $components = [];
     private array $initialized = [];
+    private CollectorRegistry $registry;
 
     public function __construct(
         private ConfigurationService $configService,
-        private ?ContainerInterface $container = null
+        private ?ContainerInterface $container = null,
+        CollectorRegistry $registry
     ) {
+        $this->registry = $registry;
         $this->registerComponents();
     }
 
@@ -369,12 +373,17 @@ class ComponentManager
                     return new $className(
                         $this,
                         $this->configService,
-                        $this->container ?? new MockContainer() 
+                        $this->container ?? new MockContainer(),
+                        $this->registry
                     );
 
                 case 'debug_bar':
                     // DebugBarHandler constructor signature now includes Container
-                    return new $className($this->configService, $this->container ?? new MockContainer()); // Pass container
+                    return new $className(
+                        $this->configService,
+                        $this->container ?? new MockContainer(),
+                        $this->registry
+                    ); // Pass container and registry
 
                 case 'whoops':
                     // WhoopsHandler constructor signature
@@ -382,7 +391,10 @@ class ComponentManager
 
                 case 'analysis':
                     // AnalysisService constructor signature
-                    return new $className($this->configService);
+                    return new $className(
+                        $this->configService,
+                        $this->getComponent('microscope')
+                    );
 
                 default:
                     // Try with ConfigurationService first

--- a/tests/Functional/MicroscopeAnalysisTest.php
+++ b/tests/Functional/MicroscopeAnalysisTest.php
@@ -10,6 +10,7 @@ use LaminasMicroscope\Manager\ComponentManager;
 use LaminasMicroscope\Config\ConfigurationService;
 use Psr\Container\ContainerInterface;
 use Laminas\Mvc\MvcEvent;
+use Laminas\Mvc\Application;
 
 class MicroscopeAnalysisTest extends TestCase
 {
@@ -17,6 +18,7 @@ class MicroscopeAnalysisTest extends TestCase
     private ComponentManager $componentManager;
     private ConfigurationService $configService;
     private ContainerInterface $container;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
     private string $tempDir;
 
     protected function setUp(): void
@@ -58,9 +60,9 @@ class MicroscopeAnalysisTest extends TestCase
         
         // Create dependencies in correct order
         $this->configService = new ConfigurationService($config);
-        $this->componentManager = new ComponentManager($this->configService);
-        $this->container = $this->createMock(ContainerInterface::class);
         $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+        $this->componentManager = new ComponentManager($this->configService, null, $this->registry);
+        $this->container = $this->createMock(ContainerInterface::class);
         
         // Create MicroscopeHandler with correct constructor signature
         $this->microscope = new MicroscopeHandler(
@@ -572,6 +574,12 @@ class MicroscopeAnalysisTest extends TestCase
         string $action = 'index'
     ): MvcEvent {
         $event = $this->createMock(MvcEvent::class);
+
+        $serviceManager = \TestHelper::createMockServiceManager();
+        $serviceManager->set(MicroscopeHandler::class, $this->microscope);
+        $application = $this->createMock(\Laminas\Mvc\Application::class);
+        $application->method('getServiceManager')->willReturn($serviceManager);
+        $event->method('getApplication')->willReturn($application);
         
         // Mock RouteMatch
         $routeMatch = $this->createMock(\Laminas\Router\RouteMatch::class);

--- a/tests/Functional/WhoopsIntegrationTest.php
+++ b/tests/Functional/WhoopsIntegrationTest.php
@@ -14,6 +14,7 @@ class WhoopsIntegrationTest extends TestCase
     private WhoopsHandler $whoops;
     private ComponentManager $componentManager;
     private ConfigurationService $configService;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
     private string $tempDir;
 
     protected function setUp(): void
@@ -44,7 +45,8 @@ class WhoopsIntegrationTest extends TestCase
         
         // Create dependencies in correct order
         $this->configService = new ConfigurationService($config);
-        $this->componentManager = new ComponentManager($this->configService);
+        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+        $this->componentManager = new ComponentManager($this->configService, null, $this->registry);
         
         // Create WhoopsHandler with correct constructor signature (only ConfigurationService)
         $this->whoops = new WhoopsHandler($this->configService);

--- a/tests/Unit/Manager/ComponentManagerTest.php
+++ b/tests/Unit/Manager/ComponentManagerTest.php
@@ -13,6 +13,7 @@ class ComponentManagerTest extends TestCase
 {
     private ComponentManager $manager;
     private ConfigurationService $configService;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
 
     protected function setUp(): void
     {
@@ -43,7 +44,8 @@ class ComponentManagerTest extends TestCase
         ]);
         
         $this->configService = new ConfigurationService($config);
-        $this->manager = new ComponentManager($this->configService);
+        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+        $this->manager = new ComponentManager($this->configService, null, $this->registry);
     }
 
     public function testGetComponentConfigReturnsConfiguration(): void
@@ -224,7 +226,8 @@ class ComponentManagerTest extends TestCase
         ]);
         
         $configService = new ConfigurationService($config);
-        $manager = new ComponentManager($configService);
+        $registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+        $manager = new ComponentManager($configService, null, $registry);
         
         $this->assertFalse($manager->hasEnabledComponents());
     }

--- a/tests/Unit/Microscope/MicroscopeHandlerTest.php
+++ b/tests/Unit/Microscope/MicroscopeHandlerTest.php
@@ -12,6 +12,7 @@ use Laminas\Mvc\MvcEvent;
 use Laminas\Router\RouteMatch;
 use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
+use Laminas\Mvc\Application;
 
 class MicroscopeHandlerTest extends TestCase
 {
@@ -20,6 +21,7 @@ class MicroscopeHandlerTest extends TestCase
     private ConfigurationService $configService;
     private ContainerInterface $container;
     private \LaminasMicroscope\Collector\CollectorRegistry $registry;
+    private Application $application;
 
     protected function setUp(): void
     {
@@ -28,7 +30,8 @@ class MicroscopeHandlerTest extends TestCase
         $this->configService = $this->createMock(ConfigurationService::class);
         $this->container = $this->createMock(ContainerInterface::class);
         $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        
+        $this->application = $this->createMock(Application::class);
+
         // Create the real handler with mocked dependencies
         $this->handler = new MicroscopeHandler(
             $this->componentManager,
@@ -36,6 +39,16 @@ class MicroscopeHandlerTest extends TestCase
             $this->container,
             $this->registry
         );
+    }
+
+    private function createEvent(): MvcEvent
+    {
+        $event = $this->createMock(MvcEvent::class);
+        $serviceManager = \TestHelper::createMockServiceManager();
+        $serviceManager->set(MicroscopeHandler::class, $this->handler);
+        $this->application->method('getServiceManager')->willReturn($serviceManager);
+        $event->method('getApplication')->willReturn($this->application);
+        return $event;
     }
 
     public function testIsEnabledReturnsTrueWhenMicroscopeEnabled(): void
@@ -129,7 +142,7 @@ class MicroscopeHandlerTest extends TestCase
             ->with('microscope')
             ->willReturn(false);
 
-        $event = $this->createMock(MvcEvent::class);
+        $event = $this->createEvent();
         $event->expects($this->never())->method('getRouteMatch');
 
         // When disabled, start profiling should complete without errors
@@ -156,7 +169,7 @@ class MicroscopeHandlerTest extends TestCase
         ]);
         $routeMatch->method('getParams')->willReturn(['controller' => 'IndexController', 'action' => 'index']);
 
-        $event = $this->createMock(MvcEvent::class);
+        $event = $this->createEvent();
         $event->method('getRouteMatch')->willReturn($routeMatch);
 
         $this->handler->startProfiling($event);
@@ -176,7 +189,7 @@ class MicroscopeHandlerTest extends TestCase
             ->with('microscope')
             ->willReturn(false);
 
-        $event = $this->createMock(MvcEvent::class);
+        $event = $this->createEvent();
 
         // When disabled, profile dispatch should complete without errors
         $this->handler->profileDispatch($event);
@@ -212,7 +225,7 @@ class MicroscopeHandlerTest extends TestCase
         // IMPORTANT: Initialize the handler first to set up $startTime
         $this->handler->initialize();
 
-        $event = $this->createMock(MvcEvent::class);
+        $event = $this->createEvent();
 
         // Now call profileDispatch - $startTime should be initialized
         $this->handler->profileDispatch($event);
@@ -284,7 +297,7 @@ class MicroscopeHandlerTest extends TestCase
         // Test the basic workflow
         $this->handler->initialize();
         
-        $event = $this->createMock(MvcEvent::class);
+        $event = $this->createEvent();
         $this->handler->startProfiling($event);
         $this->handler->profileDispatch($event);
 
@@ -348,7 +361,7 @@ class MicroscopeHandlerTest extends TestCase
 
         $this->handler->initialize();
         
-        $event = $this->createMock(MvcEvent::class);
+        $event = $this->createEvent();
         $this->handler->profileDispatch($event);
 
         $profileData = $this->handler->getProfileData();


### PR DESCRIPTION
## Summary
- add `CollectorRegistry` dependency to `ComponentManager`
- pass CollectorRegistry when creating DebugBar and Microscope handlers
- provide Microscope handler when instantiating `AnalysisService`
- update service factory for `ComponentManager`
- fix unit tests for new constructor
- update functional tests to supply application context

## Testing
- `php -d memory_limit=1024M vendor/bin/phpunit tests/Unit/Manager/ComponentManagerTest.php`
- `php -d memory_limit=1024M vendor/bin/phpunit tests/Functional/WhoopsIntegrationTest.php`
- `php -d memory_limit=1024M vendor/bin/phpunit tests/Functional/MicroscopeAnalysisTest.php` *(fails: Tests: 14, Assertions: 106, Failures: 3)*

------
https://chatgpt.com/codex/tasks/task_e_68436e5d82448331aeaf85fc716130f8