### PR TITLE
Update tests to build ComponentManager with CollectorRegistry

### DIFF
--- a/tests/Functional/MicroscopeAnalysisTest.php
+++ b/tests/Functional/MicroscopeAnalysisTest.php
@@ -59,10 +59,8 @@ class MicroscopeAnalysisTest extends TestCase
         ]);
         
         // Create dependencies in correct order
-        $this->configService = new ConfigurationService($config);
-        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        $this->componentManager = new ComponentManager($this->configService, null, $this->registry);
         $this->container = $this->createMock(ContainerInterface::class);
+        [$this->componentManager, $this->configService, $this->registry] = \TestHelper::createComponentManager($config, $this->container);
         
         // Create MicroscopeHandler with correct constructor signature
         $this->microscope = new MicroscopeHandler(

--- a/tests/Functional/WhoopsIntegrationTest.php
+++ b/tests/Functional/WhoopsIntegrationTest.php
@@ -44,9 +44,7 @@ class WhoopsIntegrationTest extends TestCase
         ]);
         
         // Create dependencies in correct order
-        $this->configService = new ConfigurationService($config);
-        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        $this->componentManager = new ComponentManager($this->configService, null, $this->registry);
+        [$this->componentManager, $this->configService, $this->registry] = \TestHelper::createComponentManager($config);
         
         // Create WhoopsHandler with correct constructor signature (only ConfigurationService)
         $this->whoops = new WhoopsHandler($this->configService);

--- a/tests/Unit/Manager/ComponentManagerTest.php
+++ b/tests/Unit/Manager/ComponentManagerTest.php
@@ -43,9 +43,7 @@ class ComponentManagerTest extends TestCase
             ],
         ]);
         
-        $this->configService = new ConfigurationService($config);
-        $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        $this->manager = new ComponentManager($this->configService, null, $this->registry);
+        [$this->manager, $this->configService, $this->registry] = \TestHelper::createComponentManager($config);
     }
 
     public function testGetComponentConfigReturnsConfiguration(): void
@@ -225,9 +223,7 @@ class ComponentManagerTest extends TestCase
             ],
         ]);
         
-        $configService = new ConfigurationService($config);
-        $registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        $manager = new ComponentManager($configService, null, $registry);
+        [$manager, $configService, $registry] = \TestHelper::createComponentManager($config);
         
         $this->assertFalse($manager->hasEnabledComponents());
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -69,26 +69,45 @@ class TestHelper
         ], $config);
     }
 
-    public static function createMockServiceManager(): object
+    public static function createMockServiceManager(): \Psr\Container\ContainerInterface
     {
-        return new class {
+        return new class implements \Psr\Container\ContainerInterface {
             private array $services = [];
             
-            public function get(string $name): mixed
+            public function get(string $id)
             {
-                return $this->services[$name] ?? null;
+                return $this->services[$id] ?? null;
             }
-            
+
             public function set(string $name, mixed $service): void
             {
                 $this->services[$name] = $service;
             }
             
-            public function has(string $name): bool
+            public function has(string $id): bool
             {
-                return isset($this->services[$name]);
+                return isset($this->services[$id]);
             }
         };
+    }
+
+    /**
+     * Helper to create a ComponentManager with a CollectorRegistry
+     */
+    public static function createComponentManager(
+        array $config = [],
+        ?object $container = null
+    ): array {
+        $configService = new \LaminasMicroscope\Config\ConfigurationService(self::createMockConfig($config));
+        $registry = new \LaminasMicroscope\Collector\CollectorRegistry();
+
+        if ($container === null) {
+            $container = self::createMockServiceManager();
+        }
+
+        $manager = new \LaminasMicroscope\Manager\ComponentManager($configService, $container, $registry);
+
+        return [$manager, $configService, $registry];
     }
 
     public static function assertArrayStructure(array $expected, array $actual, string $message = ''): void


### PR DESCRIPTION
## Summary
- add `createComponentManager()` helper in test bootstrap
- create a mock service manager implementing `ContainerInterface`
- use helper when creating `ComponentManager` in unit and functional tests

## Testing
- `composer test-unit` *(fails: LaminasMicroscopeTest\Unit\Microscope\MicroscopeHandlerTest::testProfileDispatchRecordsPerformanceDataWhenEnabled)*

------
https://chatgpt.com/codex/tasks/task_e_684370b5065c833199f3998854f69eeb