### PR TITLE
Fix navbar overlap

### DIFF
--- a/view/laminas-microscope/index.phtml
+++ b/view/laminas-microscope/index.phtml
@@ -8,7 +8,7 @@ $debugBar = Registry::getDebugBar();
 $collectorNames = $config->get('laminas_microscope.components.debug_bar.collectors', []);
 $data = $debugBar ? $debugBar->getData() : [];
 ?>
-<div class="container-fluid">
+<div class="container-fluid mt-4">
     <div class="row">
         <nav class="col-md-2 d-none d-md-block bg-light sidebar">
             <div class="position-sticky pt-3">


### PR DESCRIPTION
## Summary
- add a top margin in the dashboard to avoid nav overlap

## Testing
- `composer test` *(fails: 3 failures, 7 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684384ccc3a08331988e23f104468105