### PR TITLE
Fix debug bar timer error

### DIFF
--- a/src/DebugBar/DebugBarHandler.php
+++ b/src/DebugBar/DebugBarHandler.php
@@ -209,10 +209,17 @@ class DebugBarHandler
         // --- END DEBUG LOGGING ---
         $debugBar = $this->getDebugBar();
         if ($debugBar && $debugBar->hasCollector('time')) {
-            $debugBar->getCollector('time')->stopMeasure($name);
-             // --- DEBUG LOGGING ---
-            error_log("LaminasMicroscope: DEBUG: Timer \"{$name}\" stopped.\n");
-            // --- END DEBUG LOGGING ---
+            $collector = $debugBar->getCollector('time');
+            if (method_exists($collector, 'hasStartedMeasure') && $collector->hasStartedMeasure($name)) {
+                $collector->stopMeasure($name);
+                 // --- DEBUG LOGGING ---
+                error_log("LaminasMicroscope: DEBUG: Timer \"{$name}\" stopped.\n");
+                // --- END DEBUG LOGGING ---
+            } else {
+                 // --- DEBUG LOGGING ---
+                error_log("LaminasMicroscope: DEBUG: Timer \"{$name}\" stop skipped, not started.\n");
+                // --- END DEBUG LOGGING ---
+            }
         } else {
              // --- DEBUG LOGGING ---
             error_log("LaminasMicroscope: DEBUG: Timer \"{$name}\" not stopped. DebugBar or time collector not available.\n");


### PR DESCRIPTION
## Summary
- handle attempts to stop timers that never started

## Testing
- `composer test` *(fails: Failed asserting that an array has the key 'total_time')*

------
https://chatgpt.com/codex/tasks/task_e_68438973bec08331bcd405804b78c201