### PR TITLE
Fix debugbar collector interface path

### DIFF
--- a/src/DebugBar/Collectors/LaminasConfigCollector.php
+++ b/src/DebugBar/Collectors/LaminasConfigCollector.php
@@ -6,9 +6,10 @@ namespace LaminasMicroscope\DebugBar\Collectors;
 
 use DebugBar\DataCollector\DataCollector; 
 use DebugBar\DataCollector\Renderable; 
-use Laminas\ServiceManager\ServiceManager; 
-use Exception; 
-use ReflectionClass; 
+use Laminas\ServiceManager\ServiceManager;
+use Exception;
+use ReflectionClass;
+use LaminasMicroscope\Collector\CollectorInterface;
 
 class LaminasConfigCollector extends DataCollector implements Renderable, CollectorInterface
 {

--- a/src/DebugBar/Collectors/LaminasRequestCollector.php
+++ b/src/DebugBar/Collectors/LaminasRequestCollector.php
@@ -6,8 +6,9 @@ namespace LaminasMicroscope\DebugBar\Collectors;
 
 use DebugBar\DataCollector\DataCollector; 
 use DebugBar\DataCollector\Renderable; 
-use Laminas\ServiceManager\ServiceManager; 
-use Exception; 
+use Laminas\ServiceManager\ServiceManager;
+use Exception;
+use LaminasMicroscope\Collector\CollectorInterface;
 
 class LaminasRequestCollector extends DataCollector implements Renderable, CollectorInterface
 {

--- a/src/DebugBar/Collectors/PDOCollector.php
+++ b/src/DebugBar/Collectors/PDOCollector.php
@@ -6,9 +6,10 @@ namespace LaminasMicroscope\DebugBar\Collectors;
 
 use DebugBar\DataCollector\DataCollector; 
 use DebugBar\DataCollector\Renderable; 
-use Laminas\ServiceManager\ServiceManager; 
-use Exception; 
+use Laminas\ServiceManager\ServiceManager;
+use Exception;
 use Laminas\Db\Adapter\Adapter; // Added use statement
+use LaminasMicroscope\Collector\CollectorInterface;
 
 class PDOCollector extends DataCollector implements Renderable, CollectorInterface
 {


### PR DESCRIPTION
## Summary
- fix missing CollectorInterface by importing correct namespace

## Testing
- `composer test` *(fails: "Failed asserting that an array has the key 'total_time'.")*

------
https://chatgpt.com/codex/tasks/task_e_68438cedbd088331a61d6d9d86c8e680