### PR TITLE
Fix debugbar asset path

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -133,7 +133,13 @@ class DashboardController extends AbstractActionController
         // Construct the full path to the asset file within the vendor directory
         // This assumes the standard composer vendor path and the module is 5 levels deep
         // from the application root (vendor/icw-kb/laminas-microscope/src/Controller)
-        $assetPath = dirname(__DIR__, 5) . '/vendor/maximebf/debugbar/src/DebugBar/Resources/' . $file;
+        $basePath = dirname(__DIR__, 5);
+        $assetPath = $basePath . '/vendor/maximebf/debugbar/src/DebugBar/Resources/' . $file;
+
+        if (!file_exists($assetPath)) {
+            $basePath = dirname(__DIR__, 2);
+            $assetPath = $basePath . '/vendor/maximebf/debugbar/src/DebugBar/Resources/' . $file;
+        }
 
         // --- TEMPORARY DEBUG LOGS ---
         error_log("LaminasMicroscope: Assets Action constructed path: " . $assetPath . "\n");


### PR DESCRIPTION
## Summary
- add fallback path when serving DebugBar assets

## Testing
- `composer --no-interaction test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_6843921fd1d083319a468cfd1818cd91