### PR TITLE
Switch to inlineScript helper

### DIFF
--- a/view/laminas-microscope/config/index.phtml
+++ b/view/laminas-microscope/config/index.phtml
@@ -1,7 +1,7 @@
 <?php
 $this->headTitle('Configuration - Laminas Microscope');
 $this->headLink()->appendStylesheet('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css');
-$this->headScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
+$this->inlineScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
 ?>
 
 <div class="container-fluid mt-4">

--- a/view/laminas-microscope/index.phtml
+++ b/view/laminas-microscope/index.phtml
@@ -4,7 +4,7 @@ use LaminasMicroscope\Registry;
 
 $this->headTitle('Telescope');
 $this->headLink()->appendStylesheet('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css');
-$this->headScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
+$this->inlineScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
 
 $debugBar = Registry::getDebugBar();
 $collectorNames = $debugBar ? $debugBar->getCollectors() : [];

--- a/view/laminas-microscope/microscope/index.phtml
+++ b/view/laminas-microscope/microscope/index.phtml
@@ -2,9 +2,9 @@
 $this->headTitle('Microscope Analysis - Laminas Microscope');
 $this->headLink()->appendStylesheet('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css');
 $this->headLink()->appendStylesheet('https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/themes/prism.min.css');
-$this->headScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
-$this->headScript()->appendFile('https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/components/prism-core.min.js');
-$this->headScript()->appendFile('https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/plugins/autoloader/prism-autoloader.min.js');
+$this->inlineScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
+$this->inlineScript()->appendFile('https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/components/prism-core.min.js');
+$this->inlineScript()->appendFile('https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/plugins/autoloader/prism-autoloader.min.js');
 ?>
 
 <div class="container-fluid mt-4">

--- a/view/laminas-microscope/microscope/view.phtml
+++ b/view/laminas-microscope/microscope/view.phtml
@@ -1,7 +1,7 @@
 <?php
 $this->headTitle('Analysis Report - Laminas Microscope');
 $this->headLink()->appendStylesheet('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css');
-$this->headScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
+$this->inlineScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
 ?>
 
 <div class="container-fluid mt-4">


### PR DESCRIPTION
## Summary
- use `inlineScript()` instead of `headScript()` so included JS shows without layout changes

## Testing
- `composer test` *(fails: Script phpunit handling the test event returned with error code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68439a21569483319bd5aacea5d43c02