### PR TITLE
Fix debug bar asset path

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -130,16 +130,8 @@ class DashboardController extends AbstractActionController
             return $response;
         }
 
-        // Construct the full path to the asset file within the vendor directory
-        // This assumes the standard composer vendor path and the module is 5 levels deep
-        // from the application root (vendor/icw-kb/laminas-microscope/src/Controller)
-        $basePath = dirname(__DIR__, 5);
+        $basePath = dirname(__DIR__, 2);
         $assetPath = $basePath . '/vendor/maximebf/debugbar/src/DebugBar/Resources/' . $file;
-
-        if (!file_exists($assetPath)) {
-            $basePath = dirname(__DIR__, 2);
-            $assetPath = $basePath . '/vendor/maximebf/debugbar/src/DebugBar/Resources/' . $file;
-        }
 
         // --- TEMPORARY DEBUG LOGS ---
         error_log("LaminasMicroscope: Assets Action constructed path: " . $assetPath . "\n");


### PR DESCRIPTION
## Summary
- simplify asset path resolution for debugbar resources

## Testing
- `composer test` *(fails: No code coverage driver available)*

------
https://chatgpt.com/codex/tasks/task_e_68443d5ee1b48331a61aae814db40e46