### PR TITLE
Fix asset route path

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -229,7 +229,7 @@ return [
             'debug_bar' => [
                 // Add the base_url configuration option
                 // This should match the route defined above
-                'base_url' => '/_debug/debugbar/resources', // Updated base_url to match new route
+                'base_url' => '/debugbar/resources',
             ],
         ],
     ],

--- a/src/DebugBar/DebugBarHandler.php
+++ b/src/DebugBar/DebugBarHandler.php
@@ -114,7 +114,7 @@ class DebugBarHandler
 
         $this->renderer = $this->debugBar->getJavascriptRenderer();
         $config = $this->configService->getComponentConfig('debug_bar');
-        $baseUrl = $config['base_url'] ?? '/_debug/debugbar/resources'; // Default to the asset route
+        $baseUrl = $config['base_url'] ?? '/debugbar/resources';
 
         // REMOVED: echo "LaminasMicroscope: DebugBarHandler::initialize - Configured base_url: " . $baseUrl . "\n";
 
@@ -721,7 +721,7 @@ class DebugBarHandler
         }
 
         $config = $this->configService->getComponentConfig('debug_bar');
-        $baseUrl = $config['base_url'] ?? '/_debug/debugbar/resources'; // Default to the asset route
+        $baseUrl = $config['base_url'] ?? '/debugbar/resources';
          // --- DEBUG LOGGING ---
         error_log("LaminasMicroscope: DEBUG: getBaseUrl() returning from config: \"{$baseUrl}\".\n");
         // --- END DEBUG LOGGING ---


### PR DESCRIPTION
## Summary
- point debugbar's `base_url` to `/debugbar/resources`

## Testing
- `composer test-unit` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443f2e5818833194168289e4ce8318