### PR TITLE
Improve debugbar asset path

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace LaminasMicroscope\Controller; 
 
-use Laminas\Mvc\Controller\AbstractActionController; 
-use Laminas\View\Model\ViewModel; 
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\ViewModel;
 use LaminasMicroscope\Manager\ComponentManager;
 use LaminasMicroscope\Config\ConfigurationService;
-use Laminas\Http\Response; 
+use Laminas\Http\Response;
 use RuntimeException;
 use Exception;
 use LaminasMicroscope\Microscope\MicroscopeHandler;
-use DebugBar\JavascriptRenderer; 
+use DebugBar\JavascriptRenderer;
+use Composer\InstalledVersions;
 
 class DashboardController extends AbstractActionController
 {
@@ -130,10 +131,15 @@ class DashboardController extends AbstractActionController
             return $response;
         }
 
-        // Construct the full path to the asset file within the vendor directory
-        // This assumes the standard composer vendor path and the module is 5 levels deep
-        // from the application root (vendor/icw-kb/laminas-microscope/src/Controller)
-        $assetPath = dirname(__DIR__, 5) . '/vendor/maximebf/debugbar/src/DebugBar/Resources/' . $file;
+        try {
+            $base = InstalledVersions::getInstallPath('maximebf/debugbar');
+        } catch (\Throwable $e) {
+            $base = null;
+        }
+        if (!$base) {
+            $base = dirname(__DIR__, 5) . '/vendor/maximebf/debugbar';
+        }
+        $assetPath = $base . '/src/DebugBar/Resources/' . $file;
 
         // --- TEMPORARY DEBUG LOGS ---
         error_log("LaminasMicroscope: Assets Action constructed path: " . $assetPath . "\n");

--- a/tests/Functional/DebugBarAssetsRouteTest.php
+++ b/tests/Functional/DebugBarAssetsRouteTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasMicroscopeTest\Functional;
+
+use PHPUnit\Framework\TestCase;
+use LaminasMicroscope\Controller\DashboardController;
+use Laminas\Router\RouteMatch;
+use Laminas\Mvc\MvcEvent;
+
+class DebugBarAssetsRouteTest extends TestCase
+{
+    private DashboardController $controller;
+    private \LaminasMicroscope\Manager\ComponentManager $manager;
+    private \LaminasMicroscope\Config\ConfigurationService $configService;
+    private \LaminasMicroscope\Collector\CollectorRegistry $registry;
+
+    protected function setUp(): void
+    {
+        [$this->manager, $this->configService, $this->registry] = \TestHelper::createComponentManager();
+        $this->manager->initializeComponent('debug_bar');
+        $this->controller = new DashboardController($this->manager, $this->configService);
+    }
+
+    public function testAssetsRouteReturnsDebugbarJs(): void
+    {
+        $request = \TestHelper::createMockRequest('GET', '/debugbar/resources/debugbar.js');
+        if (method_exists($this->controller, 'setRequest')) {
+            $this->controller->setRequest($request);
+        }
+        if (method_exists($this->controller, 'setEvent')) {
+            $event = new MvcEvent();
+            $event->setRouteMatch(new RouteMatch(['file' => 'debugbar.js']));
+            $this->controller->setEvent($event);
+        }
+        $response = $this->controller->assetsAction();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertNotEmpty($response->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- reference debugbar path via InstalledVersions
- fallback to vendor path up the directory tree
- test asset delivery for debugbar.js

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6845d9afcc9c8331bc01566083381124