### PR TITLE
Fix debug bar assets

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -225,7 +225,7 @@ return [
     'laminas_microscope' => [
         'components' => [
             'debug_bar' => [
-                'base_url' => '/_debug/debugbar/resources',
+                'base_url' => '/debugbar/resources',
             ],
         ],
     ],

--- a/src/DebugBar/Collectors/PDOCollector.php
+++ b/src/DebugBar/Collectors/PDOCollector.php
@@ -6,19 +6,19 @@ namespace LaminasMicroscope\DebugBar\Collectors;
 
 use DebugBar\DataCollector\DataCollector; 
 use DebugBar\DataCollector\Renderable;
-use Laminas\ServiceManager\ServiceManager;
+use Psr\Container\ContainerInterface;
 use Exception;
 use Laminas\Db\Adapter\Adapter;
 use LaminasMicroscope\Collector\CollectorInterface;
 
 class PDOCollector extends DataCollector implements Renderable, CollectorInterface
 {
-    private ServiceManager $serviceManager;
+    private ContainerInterface $serviceManager;
     private array $queries = [];
     private array $connections = [];
     private float $totalTime = 0;
 
-    public function __construct(ServiceManager $serviceManager)
+    public function __construct(ContainerInterface $serviceManager)
     {
         $this->serviceManager = $serviceManager;
         $this->setupQueryLogging();

--- a/src/DebugBar/DebugBarHandler.php
+++ b/src/DebugBar/DebugBarHandler.php
@@ -103,7 +103,7 @@ class DebugBarHandler
 
         if (!$collectorsOnly) {
             $this->renderer = $this->debugBar->getJavascriptRenderer();
-            $baseUrl = $config['base_url'] ?? '/_debug/debugbar/resources';
+            $baseUrl = $config['base_url'] ?? '/debugbar/resources';
             if ($this->renderer && method_exists($this->renderer, 'setBaseUrl')) {
                 $this->renderer->setBaseUrl($baseUrl);
             }
@@ -358,8 +358,13 @@ class DebugBarHandler
             if ($this->container->has($mapping)) {
                 $collector = $this->container->get($mapping);
             } elseif (class_exists($mapping)) {
-                $collector = new $mapping();
-            } else {                return;
+                if ($mapping === PDOCollector::class) {
+                    $collector = new $mapping($this->container);
+                } else {
+                    $collector = new $mapping();
+                }
+            } else {
+                return;
             }
 
             $collectorName = method_exists($collector, 'getName') ? $collector->getName() : $name;
@@ -458,7 +463,7 @@ class DebugBarHandler
         }
 
         $config = $this->configService->getComponentConfig('debug_bar');
-        $baseUrl = $config['base_url'] ?? '/_debug/debugbar/resources'; // Default to the asset route
+        $baseUrl = $config['base_url'] ?? '/debugbar/resources';
         return $baseUrl;
     }
 


### PR DESCRIPTION
## Summary
- set debug bar asset route to `/debugbar/resources`
- configure DebugBarHandler renderer with new base URL
- instantiate PDOCollector with container and allow container interface

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6845de3426e483318fb04b9da79e4e47