### PR TITLE
shift collectors config

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -129,8 +129,7 @@ laminas_microscope:
       # Register collectors without injecting UI
       collectors_only: false
 
-      # Enabled collectors
-      collectors:
+  collectors:
         - 'time'         # Request timing
         - 'memory'       # Memory usage
         - 'exceptions'   # Exception tracking
@@ -234,6 +233,14 @@ laminas_microscope:
 laminas_microscope:
   enabled: true
   debug: true
+  collectors:
+    - 'time'
+    - 'memory'
+    - 'exceptions'
+    - 'pdo'
+    - 'request'
+    - 'config'
+    - 'messages'
   components:
     whoops:
       enabled: true
@@ -242,14 +249,6 @@ laminas_microscope:
     debug_bar:
       enabled: true
       collectors_only: true
-      collectors:
-        - 'time'
-        - 'memory'
-        - 'exceptions'
-        - 'pdo'
-        - 'request'
-        - 'config'
-        - 'messages'
     microscope:
       enabled: true
       auto_analyze: true
@@ -265,16 +264,16 @@ laminas_microscope:
   debug: false
   ip_whitelist:
     - '192.168.1.0/24'
+  collectors:
+    - 'time'
+    - 'memory'
+    - 'pdo'
   components:
     whoops:
       enabled: true
       show_in_production: false
     debug_bar:
       enabled: true
-      collectors:
-        - 'time'
-        - 'memory'
-        - 'pdo'
     microscope:
       enabled: true
       auto_analyze: false
@@ -323,15 +322,15 @@ laminas_microscope:
 ```yaml
 # config/autoload/debug-suite/performance.yaml
 laminas_microscope:
+  collectors:
+    - 'time'
+    - 'memory'
+    - 'pdo'
   components:
     whoops:
       enabled: false
     debug_bar:
       enabled: true
-      collectors:
-        - 'time'
-        - 'memory'
-        - 'pdo'
     microscope:
       enabled: true
       auto_analyze: true
@@ -347,19 +346,19 @@ laminas_microscope:
 # config/autoload/debug-suite/debugging.yaml
 laminas_microscope:
   debug: true
+  collectors:
+    - 'time'
+    - 'memory'
+    - 'exceptions'
+    - 'pdo'
+    - 'request'
+    - 'config'
+    - 'messages'
   components:
     whoops:
       enabled: true
     debug_bar:
       enabled: true
-      collectors:
-        - 'time'
-        - 'memory'
-        - 'exceptions'
-        - 'pdo'
-        - 'request'
-        - 'config'
-        - 'messages'
     microscope:
       enabled: true
       auto_analyze: true
@@ -545,10 +544,10 @@ laminas_microscope:
 ```yaml
 laminas_microscope:
   enabled: true
+  collectors: ['time', 'memory', 'pdo']
   components:
     debug_bar:
       enabled: true
-      collectors: ['time', 'memory', 'pdo']
     microscope:
       enabled: true
       auto_analyze: true

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -88,6 +88,14 @@ Edit `config/autoload/laminas-microscope.local.php`:
 laminas_microscope:
   enabled: true
   environment: 'development'
+  collectors:
+    - 'time'
+    - 'memory'
+    - 'exceptions'
+    - 'pdo'
+    - 'request'
+    - 'config'
+    - 'messages'
   components:
     whoops:
       enabled: true
@@ -96,14 +104,6 @@ laminas_microscope:
     debug_bar:
       enabled: true
       position: 'bottom'
-      collectors:
-        - 'time'
-        - 'memory'
-        - 'exceptions'
-        - 'pdo'
-        - 'request'
-        - 'config'
-        - 'messages'
     microscope:
       enabled: true
       auto_analyze: true
@@ -154,12 +154,12 @@ laminas_microscope:
 ```yaml
 laminas_microscope:
   enabled: true
+  collectors: ['time', 'memory', 'pdo']
   components:
     whoops:
       enabled: false
     debug_bar:
       enabled: true
-      collectors: ['time', 'memory', 'pdo']
     microscope:
       enabled: true
       auto_analyze: true
@@ -169,12 +169,12 @@ laminas_microscope:
 ```yaml
 laminas_microscope:
   enabled: true
+  collectors: ['time', 'memory', 'exceptions', 'pdo', 'request', 'config', 'messages']
   components:
     whoops:
       enabled: true
     debug_bar:
       enabled: true
-      collectors: ['time', 'memory', 'exceptions', 'pdo', 'request', 'config', 'messages']
     microscope:
       enabled: true
       auto_analyze: true

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ laminas_microscope:
 ```yaml
 laminas_microscope:
   enabled: true
+  collectors: ['time', 'memory', 'pdo']
   components:
     whoops:
       enabled: false
     debug_bar:
       enabled: true
       collectors_only: true
-      collectors: ['time', 'memory', 'pdo']
     microscope:
       enabled: true
       auto_analyze: true
@@ -128,13 +128,13 @@ laminas_microscope:
 ```yaml
 laminas_microscope:
   enabled: true
+  collectors: ['time', 'memory', 'exceptions', 'pdo', 'request', 'config', 'messages']
   components:
     whoops:
       enabled: true
     debug_bar:
       enabled: true
       collectors_only: true
-      collectors: ['time', 'memory', 'exceptions', 'pdo', 'request', 'config', 'messages']
     microscope:
       enabled: true
       auto_analyze: true

--- a/USAGE.md
+++ b/USAGE.md
@@ -316,12 +316,13 @@ Access configuration at `/_debug/config`.
 #### Debug Bar Collectors
 ```yaml
 # Enable specific collectors
-collectors:
-  - 'time'       # ✅ Performance timing
-  - 'memory'     # ✅ Memory usage
-  - 'pdo'        # ✅ Database queries
-  - 'request'    # ❌ HTTP request data
-  - 'config'     # ❌ Configuration dump
+laminas_microscope:
+  collectors:
+    - 'time'       # ✅ Performance timing
+    - 'memory'     # ✅ Memory usage
+    - 'pdo'        # ✅ Database queries
+    - 'request'    # ❌ HTTP request data
+    - 'config'     # ❌ Configuration dump
 ```
 
 ### 📋 Configuration Profiles
@@ -508,12 +509,12 @@ ini_set('memory_limit', '256M');
 ```yaml
 # Reduce debug overhead
 laminas_microscope:
+  collectors:
+    - 'time'    # Keep essential only
+    - 'memory'
+    - 'pdo'
   components:
     debug_bar:
-      collectors:
-        - 'time'    # Keep essential only
-        - 'memory'
-        - 'pdo'
     microscope:
       auto_analyze: false  # Disable auto-analysis
       analysis_frequency: 10  # Analyze every 10th request

--- a/config/components/debug_bar.yaml
+++ b/config/components/debug_bar.yaml
@@ -5,14 +5,6 @@ storage:
   enabled: true
   driver: 'file'
   path: '/tmp/debugbar'
-collectors:
-  - 'time'
-  - 'memory'
-  - 'exceptions'
-  - 'pdo'
-  - 'request'
-  - 'config'
-  - 'messages'
 exclude_paths:
   - '/health'
   - '/metrics'

--- a/config/laminas-microscope.local.php
+++ b/config/laminas-microscope.local.php
@@ -4,6 +4,14 @@ return [
     'laminas_microscope' => [
         'enabled' => true,
         'environment' => 'development',
+        'collectors' => [
+            'time',
+            'memory',
+            'exceptions',
+            'pdo',
+            'request',
+            'config',
+        ],
         'storage' => [
             'path' => '/tmp/laminas-microscope',
         ],
@@ -19,14 +27,6 @@ return [
                 'position' => 'bottom',
                 'max_queries' => 100,
                 'collectors_only' => false,
-                'collectors' => [
-                    'time',
-                    'memory',
-                    'exceptions',
-                    'pdo',
-                    'request',
-                    'config',
-                ],
             ],
             'microscope' => [
                 'enabled' => true,

--- a/src/DebugBar/DebugBarHandler.php
+++ b/src/DebugBar/DebugBarHandler.php
@@ -437,7 +437,7 @@ class DebugBarHandler
         }
 
         $config = $this->configService->getComponentConfig('debug_bar');
-        $collectors = $config['collectors'] ?? ['time', 'memory', 'messages'];
+        $collectors = $this->configService->get('laminas_microscope.collectors', $config['collectors'] ?? ['time', 'memory', 'messages']);
 
         // --- DEBUG LOGGING ---
         error_log("LaminasMicroscope: DEBUG: Configured collectors: " . implode(', ', $collectors) . ".\n");

--- a/src/Service/ConfigurationManager.php
+++ b/src/Service/ConfigurationManager.php
@@ -94,6 +94,7 @@ class ConfigurationManager
                 'enabled' => true,
                 'environment' => 'development',
                 'debug_mode' => false,
+                'collectors' => ['time', 'memory', 'pdo'],
                 'storage' => [
                     'path' => 'data/laminas-microscope',
                     'retention_days' => 30,
@@ -107,7 +108,6 @@ class ConfigurationManager
                     ],
                     'debug_bar' => [
                         'enabled' => true,
-                        'collectors' => ['time', 'memory', 'pdo'],
                     ],
                     'microscope' => [
                         'enabled' => true,

--- a/tests/Functional/DebugBarIntegrationTest.php
+++ b/tests/Functional/DebugBarIntegrationTest.php
@@ -21,10 +21,10 @@ class DebugBarIntegrationTest extends TestCase
             'laminas_microscope' => [
                 'enabled' => true,
                 'environment' => 'testing',
+                'collectors' => ['time', 'memory', 'messages'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => true,
-                        'collectors' => ['time', 'memory', 'messages'], // Removed phpinfo to avoid conflicts
                         'inject_into_response' => true,
                     ],
                 ],
@@ -334,10 +334,10 @@ class DebugBarIntegrationTest extends TestCase
             'laminas_microscope' => [
                 'enabled' => true,
                 'environment' => 'testing',
+                'collectors' => ['time', 'memory', 'messages', 'phpinfo'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => true,
-                        'collectors' => ['time', 'memory', 'messages', 'phpinfo'],
                     ],
                 ],
             ],
@@ -387,10 +387,10 @@ class DebugBarIntegrationTest extends TestCase
             'laminas_microscope' => [
                 'enabled' => true,
                 'environment' => 'testing',
+                'collectors' => ['phpinfo'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => true,
-                        'collectors' => ['phpinfo'], // Only phpinfo to test conflict handling
                     ],
                 ],
             ],

--- a/tests/Unit/Config/ConfigurationServiceTest.php
+++ b/tests/Unit/Config/ConfigurationServiceTest.php
@@ -52,7 +52,7 @@ class ConfigurationServiceTest extends TestCase
 
     public function testGetWithArrayValue(): void
     {
-        $value = $this->configService->get('laminas_microscope.components.debug_bar.collectors');
+        $value = $this->configService->get('laminas_microscope.collectors');
         $this->assertIsArray($value);
         $this->assertContains('time', $value);
         $this->assertContains('memory', $value);

--- a/tests/Unit/Controller/DashboardControllerTest.php
+++ b/tests/Unit/Controller/DashboardControllerTest.php
@@ -15,11 +15,11 @@ class DashboardControllerTest extends TestCase
     {
         $config = [
             'laminas_microscope' => [
+                'collectors' => ['time', 'memory'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => false,
                         'collectors_only' => true,
-                        'collectors' => ['time', 'memory'],
                     ],
                 ],
             ],

--- a/tests/Unit/DebugBar/DebugBarHandlerTest.php
+++ b/tests/Unit/DebugBar/DebugBarHandlerTest.php
@@ -20,10 +20,10 @@ class DebugBarHandlerTest extends TestCase
         $config = \TestHelper::createMockConfig([
             'laminas_microscope' => [
                 'enabled' => true,
+                'collectors' => ['time', 'memory', 'messages'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => true,
-                        'collectors' => ['time', 'memory', 'messages'],
                         'show_in_production' => false,
                     ],
                 ],
@@ -585,10 +585,10 @@ class DebugBarHandlerTest extends TestCase
             $config = \TestHelper::createMockConfig([
                 'laminas_microscope' => [
                     'enabled' => true,
+                    'collectors' => $configuredCollectors,
                     'components' => [
                         'debug_bar' => [
                             'enabled' => true,
-                            'collectors' => $configuredCollectors,
                         ],
                     ],
                 ],
@@ -667,11 +667,11 @@ class DebugBarHandlerTest extends TestCase
     {
         $config = \TestHelper::createMockConfig([
             'laminas_microscope' => [
+                'collectors' => ['time'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => false,
                         'collectors_only' => true,
-                        'collectors' => ['time'],
                     ],
                 ],
             ],

--- a/tests/Unit/Manager/ComponentManagerTest.php
+++ b/tests/Unit/Manager/ComponentManagerTest.php
@@ -20,11 +20,11 @@ class ComponentManagerTest extends TestCase
         $config = \TestHelper::createMockConfig([
             'laminas_microscope' => [
                 'enabled' => true,
+                'collectors' => ['time', 'memory'],
                 'components' => [
                     'debug_bar' => [
                         'enabled' => true,
                         'type' => 'profiler',
-                        'collectors' => ['time', 'memory'],
                     ],
                     'whoops' => [
                         'enabled' => false,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,6 +51,7 @@ class TestHelper
                     'path' => sys_get_temp_dir() . '/laminas-microscope-test',
                     'retention_days' => 7,
                 ],
+                'collectors' => ['time', 'memory', 'pdo'],
                 'components' => [
                     'whoops' => [
                         'enabled' => true,
@@ -58,7 +59,6 @@ class TestHelper
                     ],
                     'debug_bar' => [
                         'enabled' => true,
-                        'collectors' => ['time', 'memory', 'pdo'],
                     ],
                     'microscope' => [
                         'enabled' => true,

--- a/tests/config/testing.global.php
+++ b/tests/config/testing.global.php
@@ -15,18 +15,18 @@ return [
                 'show_in_production' => false,
                 'editor' => 'vscode',
             ],
+            'collectors' => [
+                'time',
+                'memory',
+                'exceptions',
+                'pdo',
+                'request',
+                'config',
+                'messages',
+            ],
             'debug_bar' => [
                 'enabled' => true,
                 'position' => 'bottom',
-                'collectors' => [
-                    'time',
-                    'memory',
-                    'exceptions',
-                    'pdo',
-                    'request',
-                    'config',
-                    'messages',
-                ],
             ],
             'microscope' => [
                 'enabled' => true,

--- a/view/laminas-microscope/config/index.phtml
+++ b/view/laminas-microscope/config/index.phtml
@@ -183,7 +183,7 @@ $this->headScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/di
                                         <div class="mb-3">
                                             <label class="form-label">Collectors</label>
                                             <?php $collectors = ['time', 'memory', 'exceptions', 'pdo', 'request', 'config', 'messages']; ?>
-                                            <?php $enabledCollectors = $config->get('laminas_microscope.components.debug_bar.collectors', $collectors); ?>
+                                            <?php $enabledCollectors = $config->get('laminas_microscope.collectors', $collectors); ?>
                                             <?php foreach ($collectors as $collector): ?>
                                                 <div class="form-check">
                                                     <input class="form-check-input" type="checkbox" id="collector_<?= $collector ?>"

--- a/view/laminas-microscope/config/profiles.phtml
+++ b/view/laminas-microscope/config/profiles.phtml
@@ -142,9 +142,10 @@ const profiles = {
         name: 'Performance',
         description: 'Debug Bar and Microscope for performance monitoring',
         config: {
+            collectors: ['time', 'memory', 'pdo'],
             components: {
                 whoops: { enabled: false },
-                debug_bar: { enabled: true, collectors: ['time', 'memory', 'pdo'] },
+                debug_bar: { enabled: true },
                 microscope: { enabled: true, auto_analyze: true }
             }
         }
@@ -153,9 +154,10 @@ const profiles = {
         name: 'Full Debugging',
         description: 'All components enabled for complete debugging',
         config: {
+            collectors: ['time', 'memory', 'exceptions', 'pdo', 'request', 'config'],
             components: {
                 whoops: { enabled: true, show_in_production: false },
-                debug_bar: { enabled: true, collectors: ['time', 'memory', 'exceptions', 'pdo', 'request', 'config'] },
+                debug_bar: { enabled: true },
                 microscope: { enabled: true, auto_analyze: true }
             }
         }

--- a/view/laminas-microscope/index.phtml
+++ b/view/laminas-microscope/index.phtml
@@ -5,7 +5,7 @@ $this->headTitle('Microscope');
 $this->headLink()->appendStylesheet('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css');
 $this->headScript()->appendFile('https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js');
 $debugBar = Registry::getDebugBar();
-$collectorNames = $config->get('laminas_microscope.components.debug_bar.collectors', []);
+$collectorNames = $config->get('laminas_microscope.collectors', []);
 $data = $debugBar ? $debugBar->getData() : [];
 ?>
 <div class="container-fluid">


### PR DESCRIPTION
## Summary
- move collectors under the `laminas_microscope` root key
- default to new collectors location in config service
- update debug bar handler to read from new path
- adjust tests and docs for moved collectors

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6845fcc71c388331bf47cd2387f1d07a