### PR TITLE
refactor: Move collector mapping from CollectorFactory to configuration

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -258,5 +258,42 @@ return [
                 'base_url' => '/_debug/debugbar/resources', // Updated base_url to match new route
             ],
         ],
+        'collector_mapping' => [
+            'time'     => [
+                'class'   => \DebugBar\DataCollector\TimeDataCollector::class,
+                'factory' => 'direct',
+            ],
+            'memory'   => [
+                'class'   => \DebugBar\DataCollector\MemoryCollector::class,
+                'factory' => 'direct',
+            ],
+            'messages' => [
+                'class'   => \DebugBar\DataCollector\MessagesCollector::class,
+                'factory' => 'direct',
+            ],
+            'phpinfo'  => [
+                'class'   => \DebugBar\DataCollector\PhpInfoCollector::class,
+                'factory' => 'direct',
+            ],
+            'php'      => [
+                'class'   => \DebugBar\DataCollector\PhpInfoCollector::class,
+                'factory' => 'direct',
+            ],
+            'config'   => [
+                'class'        => LaminasConfigCollector::class,
+                'factory'      => 'service',
+                'service_name' => LaminasConfigCollector::class,
+            ],
+            'pdo'      => [
+                'class'        => PDOCollector::class,
+                'factory'      => 'service',
+                'service_name' => PDOCollector::class,
+            ],
+            'request'  => [
+                'class'        => LaminasRequestCollector::class,
+                'factory'      => 'service',
+                'service_name' => LaminasRequestCollector::class,
+            ],
+        ],
     ],
 ];

--- a/src/DebugBar/CollectorFactory.php
+++ b/src/DebugBar/CollectorFactory.php
@@ -23,51 +23,12 @@ use function error_log;
 class CollectorFactory
 {
     private ContainerInterface $container;
+    private array $collectorMapping;
 
-    /**
-     * Collector configuration mapping
-     */
-    private const COLLECTOR_MAPPING = [
-        'time'     => [
-            'class'   => TimeDataCollector::class,
-            'factory' => 'direct',
-        ],
-        'memory'   => [
-            'class'   => MemoryCollector::class,
-            'factory' => 'direct',
-        ],
-        'messages' => [
-            'class'   => MessagesCollector::class,
-            'factory' => 'direct',
-        ],
-        'phpinfo'  => [
-            'class'   => PhpInfoCollector::class,
-            'factory' => 'direct',
-        ],
-        'php'      => [
-            'class'   => PhpInfoCollector::class,
-            'factory' => 'direct',
-        ],
-        'config'   => [
-            'class'        => LaminasConfigCollector::class,
-            'factory'      => 'service',
-            'service_name' => LaminasConfigCollector::class,
-        ],
-        'pdo'      => [
-            'class'        => PDOCollector::class,
-            'factory'      => 'service',
-            'service_name' => PDOCollector::class,
-        ],
-        'request'  => [
-            'class'        => LaminasRequestCollector::class,
-            'factory'      => 'service',
-            'service_name' => LaminasRequestCollector::class,
-        ],
-    ];
-
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, array $collectorMapping = [])
     {
         $this->container = $container;
+        $this->collectorMapping = $collectorMapping;
     }
 
     /**
@@ -78,11 +39,11 @@ class CollectorFactory
      */
     public function create(string $name): ?DataCollectorInterface
     {
-        if (! isset(self::COLLECTOR_MAPPING[$name])) {
+        if (! isset($this->collectorMapping[$name])) {
             return null;
         }
 
-        $config = self::COLLECTOR_MAPPING[$name];
+        $config = $this->collectorMapping[$name];
 
         try {
             if ($config['factory'] === 'direct') {
@@ -114,7 +75,7 @@ class CollectorFactory
      */
     public function getCollectorConfig(string $name): ?array
     {
-        return self::COLLECTOR_MAPPING[$name] ?? null;
+        return $this->collectorMapping[$name] ?? null;
     }
 
     /**
@@ -124,7 +85,7 @@ class CollectorFactory
      */
     public function getAvailableCollectors(): array
     {
-        return array_keys(self::COLLECTOR_MAPPING);
+        return array_keys($this->collectorMapping);
     }
 
     /**

--- a/src/Factory/CollectorFactoryFactory.php
+++ b/src/Factory/CollectorFactoryFactory.php
@@ -15,6 +15,9 @@ class CollectorFactoryFactory implements FactoryInterface
         $requestedName,
         ?array $options = null
     ): CollectorFactory {
-        return new CollectorFactory($container);
+        $config = $container->get('config');
+        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+        
+        return new CollectorFactory($container, $collectorMapping);
     }
 }

--- a/src/Manager/ComponentManager.php
+++ b/src/Manager/ComponentManager.php
@@ -407,7 +407,9 @@ class ComponentManager
                         $collectorFactory = $this->container->get(CollectorFactory::class);
                     } else {
                         // Create a basic CollectorFactory for testing scenarios
-                        $collectorFactory = new CollectorFactory($this->container ?? new MockContainer());
+                        $config = $this->configService->getAll();
+                        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+                        $collectorFactory = new CollectorFactory($this->container ?? new MockContainer(), $collectorMapping);
                     }
                     return new $className(
                         $this->configService,

--- a/tests/Functional/DebugBarIntegrationTest.php
+++ b/tests/Functional/DebugBarIntegrationTest.php
@@ -36,7 +36,8 @@ class DebugBarIntegrationTest extends TestCase
         $this->configService = new ConfigurationService($config);
         $this->container = \TestHelper::createMockServiceManager();
         $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        $this->collectorFactory = new CollectorFactory($this->container);
+        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+        $this->collectorFactory = new CollectorFactory($this->container, $collectorMapping);
         $this->debugBar = new DebugBarHandler($this->configService, $this->container, $this->registry, $this->collectorFactory);
     }
 

--- a/tests/Integration/ActualDisplayTest.php
+++ b/tests/Integration/ActualDisplayTest.php
@@ -63,7 +63,8 @@ class ActualDisplayTest extends TestCase
         $this->container->set(LaminasRequestCollector::class, new LaminasRequestCollector($serviceManager));
         $this->container->set(PDOCollector::class, new PDOCollector($serviceManager, true));
         
-        $this->collectorFactory = new CollectorFactory($this->container);
+        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+        $this->collectorFactory = new CollectorFactory($this->container, $collectorMapping);
     }
     
     public function testDebugBarWidgetOutput(): void

--- a/tests/Integration/CollectorIntegrationTest.php
+++ b/tests/Integration/CollectorIntegrationTest.php
@@ -63,7 +63,8 @@ class CollectorIntegrationTest extends TestCase
         $this->container->set(LaminasRequestCollector::class, new LaminasRequestCollector($serviceManager));
         $this->container->set(PDOCollector::class, new PDOCollector($serviceManager, true));
         
-        $this->collectorFactory = new CollectorFactory($this->container);
+        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+        $this->collectorFactory = new CollectorFactory($this->container, $collectorMapping);
     }
     
     public function testDebugBarShowsConfiguredCollectors(): void

--- a/tests/Unit/BaseTestCase.php
+++ b/tests/Unit/BaseTestCase.php
@@ -73,4 +73,19 @@ abstract class BaseTestCase extends TestCase
     {
         return \TestHelper::createMockConfig($overrides);
     }
+
+    /**
+     * Create a CollectorFactory with default mapping
+     */
+    protected function createCollectorFactory($container = null): \LaminasMicroscope\DebugBar\CollectorFactory
+    {
+        if ($container === null) {
+            $container = \TestHelper::createMockServiceManager();
+        }
+        
+        $config = $this->getMockConfig();
+        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+        
+        return new \LaminasMicroscope\DebugBar\CollectorFactory($container, $collectorMapping);
+    }
 }

--- a/tests/Unit/Controller/DashboardControllerTest.php
+++ b/tests/Unit/Controller/DashboardControllerTest.php
@@ -20,6 +20,7 @@ class DashboardControllerTest extends TestCase
                     'debug_bar' => [
                         'enabled' => false,
                         'collectors_only' => true,
+                        'collectors' => ['time', 'memory'],  // Add collectors to debug_bar config
                     ],
                 ],
             ],

--- a/tests/Unit/DebugBar/CollectorFactoryTest.php
+++ b/tests/Unit/DebugBar/CollectorFactoryTest.php
@@ -10,18 +10,19 @@ use DebugBar\DataCollector\TimeDataCollector;
 use LaminasMicroscope\DebugBar\CollectorFactory;
 use LaminasMicroscope\DebugBar\Collectors\PDOCollector;
 use LaminasMicroscope\Exception\ConfigurationException;
-use PHPUnit\Framework\TestCase;
+use LaminasMicroscopeTest\Unit\BaseTestCase;
 use Psr\Container\ContainerInterface;
 
-class CollectorFactoryTest extends TestCase
+class CollectorFactoryTest extends BaseTestCase
 {
     private CollectorFactory $factory;
     private ContainerInterface $container;
 
     protected function setUp(): void
     {
+        parent::setUp();
         $this->container = $this->createMock(ContainerInterface::class);
-        $this->factory = new CollectorFactory($this->container);
+        $this->factory = $this->createCollectorFactory($this->container);
     }
 
     public function testCreateDirectCollector(): void

--- a/tests/Unit/DebugBar/DebugBarHandlerTest.php
+++ b/tests/Unit/DebugBar/DebugBarHandlerTest.php
@@ -35,7 +35,8 @@ class DebugBarHandlerTest extends TestCase
         $this->configService = new ConfigurationService($config);
         $this->container = \TestHelper::createMockServiceManager();
         $this->registry = new \LaminasMicroscope\Collector\CollectorRegistry();
-        $this->collectorFactory = new CollectorFactory($this->container);
+        $collectorMapping = $config['laminas_microscope']['collector_mapping'] ?? [];
+        $this->collectorFactory = new CollectorFactory($this->container, $collectorMapping);
         $this->handler = new DebugBarHandler($this->configService, $this->container, $this->registry, $this->collectorFactory);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -65,6 +65,43 @@ class TestHelper
                         'auto_analyze' => false,
                     ],
                 ],
+                'collector_mapping' => [
+                    'time'     => [
+                        'class'   => \DebugBar\DataCollector\TimeDataCollector::class,
+                        'factory' => 'direct',
+                    ],
+                    'memory'   => [
+                        'class'   => \DebugBar\DataCollector\MemoryCollector::class,
+                        'factory' => 'direct',
+                    ],
+                    'messages' => [
+                        'class'   => \DebugBar\DataCollector\MessagesCollector::class,
+                        'factory' => 'direct',
+                    ],
+                    'phpinfo'  => [
+                        'class'   => \DebugBar\DataCollector\PhpInfoCollector::class,
+                        'factory' => 'direct',
+                    ],
+                    'php'      => [
+                        'class'   => \DebugBar\DataCollector\PhpInfoCollector::class,
+                        'factory' => 'direct',
+                    ],
+                    'config'   => [
+                        'class'        => \LaminasMicroscope\DebugBar\Collectors\LaminasConfigCollector::class,
+                        'factory'      => 'service',
+                        'service_name' => \LaminasMicroscope\DebugBar\Collectors\LaminasConfigCollector::class,
+                    ],
+                    'pdo'      => [
+                        'class'        => \LaminasMicroscope\DebugBar\Collectors\PDOCollector::class,
+                        'factory'      => 'service',
+                        'service_name' => \LaminasMicroscope\DebugBar\Collectors\PDOCollector::class,
+                    ],
+                    'request'  => [
+                        'class'        => \LaminasMicroscope\DebugBar\Collectors\LaminasRequestCollector::class,
+                        'factory'      => 'service',
+                        'service_name' => \LaminasMicroscope\DebugBar\Collectors\LaminasRequestCollector::class,
+                    ],
+                ],
             ],
         ], $config);
     }
@@ -98,12 +135,18 @@ class TestHelper
         array $config = [],
         ?object $container = null
     ): array {
-        $configService = new \LaminasMicroscope\Config\ConfigurationService(self::createMockConfig($config));
+        $fullConfig = self::createMockConfig($config);
+        $configService = new \LaminasMicroscope\Config\ConfigurationService($fullConfig);
         $registry = new \LaminasMicroscope\Collector\CollectorRegistry();
 
         if ($container === null) {
             $container = self::createMockServiceManager();
         }
+        
+        // Add CollectorFactory to the container
+        $collectorMapping = $fullConfig['laminas_microscope']['collector_mapping'] ?? [];
+        $collectorFactory = new \LaminasMicroscope\DebugBar\CollectorFactory($container, $collectorMapping);
+        $container->set(\LaminasMicroscope\DebugBar\CollectorFactory::class, $collectorFactory);
 
         $manager = new \LaminasMicroscope\Manager\ComponentManager($configService, $registry, $container);
 

--- a/tests/config/testing.global.php
+++ b/tests/config/testing.global.php
@@ -42,6 +42,43 @@ return [
                 ],
             ],
         ],
+        'collector_mapping' => [
+            'time'     => [
+                'class'   => \DebugBar\DataCollector\TimeDataCollector::class,
+                'factory' => 'direct',
+            ],
+            'memory'   => [
+                'class'   => \DebugBar\DataCollector\MemoryCollector::class,
+                'factory' => 'direct',
+            ],
+            'messages' => [
+                'class'   => \DebugBar\DataCollector\MessagesCollector::class,
+                'factory' => 'direct',
+            ],
+            'phpinfo'  => [
+                'class'   => \DebugBar\DataCollector\PhpInfoCollector::class,
+                'factory' => 'direct',
+            ],
+            'php'      => [
+                'class'   => \DebugBar\DataCollector\PhpInfoCollector::class,
+                'factory' => 'direct',
+            ],
+            'config'   => [
+                'class'        => \LaminasMicroscope\DebugBar\Collectors\LaminasConfigCollector::class,
+                'factory'      => 'service',
+                'service_name' => \LaminasMicroscope\DebugBar\Collectors\LaminasConfigCollector::class,
+            ],
+            'pdo'      => [
+                'class'        => \LaminasMicroscope\DebugBar\Collectors\PDOCollector::class,
+                'factory'      => 'service',
+                'service_name' => \LaminasMicroscope\DebugBar\Collectors\PDOCollector::class,
+            ],
+            'request'  => [
+                'class'        => \LaminasMicroscope\DebugBar\Collectors\LaminasRequestCollector::class,
+                'factory'      => 'service',
+                'service_name' => \LaminasMicroscope\DebugBar\Collectors\LaminasRequestCollector::class,
+            ],
+        ],
     ],
     'db' => [
         'driver' => 'Pdo_Sqlite',


### PR DESCRIPTION
## Summary
This PR moves the hardcoded `COLLECTOR_MAPPING` constant from the `CollectorFactory` class to the module configuration file, making the collector system more flexible and configurable.

## Changes
- Extract `COLLECTOR_MAPPING` constant to `module.config.php` under `laminas_microscope.collector_mapping`
- Update `CollectorFactory` to accept mapping via constructor injection
- Update `CollectorFactoryFactory` to read mapping from configuration
- Add collector mapping to test bootstrap and configuration files
- Update all test files to provide collector mapping when creating CollectorFactory
- Add `createCollectorFactory()` helper method in BaseTestCase

## Benefits
- Makes the collector system more flexible and extensible
- Follows Laminas best practices by centralizing configuration
- Allows for easier modification and extension without code changes
- Enables custom collector mappings per environment or deployment

## Test Results
All CollectorFactory unit tests pass successfully after the refactoring.

🤖 Generated with [Claude Code](https://claude.ai/code)